### PR TITLE
SwiftUI - Simple and Detail Contact Views

### DIFF
--- a/CareKit/CareKit.xcodeproj/project.pbxproj
+++ b/CareKit/CareKit.xcodeproj/project.pbxproj
@@ -147,6 +147,14 @@
 		64EABE022321B1AF00CFBB9F /* OCKSynchronizedStoreManager+Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EABDBF2321B1AF00CFBB9F /* OCKSynchronizedStoreManager+Publishers.swift */; };
 		64EABE0B2321B1AF00CFBB9F /* OCKContactUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EABDCB2321B1AF00CFBB9F /* OCKContactUtility.swift */; };
 		64EABE202321B1AF00CFBB9F /* locversion.plist in Resources */ = {isa = PBXBuildFile; fileRef = 64EABDE72321B1AF00CFBB9F /* locversion.plist */; };
+		B046D07824B3BD630005F316 /* OCKContactController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B046D07724B3BD630005F316 /* OCKContactController+Extensions.swift */; };
+		B046D07924B3BD630005F316 /* OCKContactController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B046D07724B3BD630005F316 /* OCKContactController+Extensions.swift */; };
+		B046D07B24B3D65B0005F316 /* TestSimpleContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B046D07A24B3D65B0005F316 /* TestSimpleContactView.swift */; };
+		B046D07D24B3D6670005F316 /* TestDetailedContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B046D07C24B3D6670005F316 /* TestDetailedContactView.swift */; };
+		B046D07F24B3DD5B0005F316 /* TestDetailedContactViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B046D07E24B3DD5B0005F316 /* TestDetailedContactViewModel.swift */; };
+		B09EFD9C24AB711500FF5C4F /* SimpleContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD9B24AB711500FF5C4F /* SimpleContactView.swift */; };
+		B0A3840524B0B73100384A64 /* DetailedContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A3840424B0B73100384A64 /* DetailedContactView.swift */; };
+		B0B50D3424ABCD4900AC8192 /* SynchronizedContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B50D3324ABCD4900AC8192 /* SynchronizedContactView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -286,6 +294,13 @@
 		64EABDE52321B1AF00CFBB9F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64EABDE82321B1AF00CFBB9F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = en; path = en.lproj/locversion.plist; sourceTree = "<group>"; };
 		8605A5BA1C4F04EC00DD65FF /* CareKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CareKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B046D07724B3BD630005F316 /* OCKContactController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKContactController+Extensions.swift"; sourceTree = "<group>"; };
+		B046D07A24B3D65B0005F316 /* TestSimpleContactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSimpleContactView.swift; sourceTree = "<group>"; };
+		B046D07C24B3D6670005F316 /* TestDetailedContactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDetailedContactView.swift; sourceTree = "<group>"; };
+		B046D07E24B3DD5B0005F316 /* TestDetailedContactViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDetailedContactViewModel.swift; sourceTree = "<group>"; };
+		B09EFD9B24AB711500FF5C4F /* SimpleContactView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleContactView.swift; sourceTree = "<group>"; };
+		B0A3840424B0B73100384A64 /* DetailedContactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailedContactView.swift; sourceTree = "<group>"; };
+		B0B50D3324ABCD4900AC8192 /* SynchronizedContactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedContactView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -342,6 +357,7 @@
 				0346743D2397026A0074891C /* os_log+CareKit.swift */,
 				64EABDBC2321B1AF00CFBB9F /* Synchronization */,
 				510466FE24A2873A00D0FD53 /* Task */,
+				B09EFD9A24AB6D9700FF5C4F /* Contact */,
 				510466FD24A2871800D0FD53 /* Extensions */,
 				5104670024A28C7600D0FD53 /* Utilities */,
 			);
@@ -351,6 +367,7 @@
 		510466FD24A2871800D0FD53 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B046D07724B3BD630005F316 /* OCKContactController+Extensions.swift */,
 				515C0A1523BF9D3C009A9774 /* OCKTaskControllerProtocol+Extension.swift */,
 				5125A214248F2E00009C9643 /* OCKTaskEvents+Extension.swift */,
 				032C86EF2326B68D00D0A0EA /* Calendar+Extensions.swift */,
@@ -562,6 +579,9 @@
 				518E153A237265930018541B /* TestSimpleContactViewSynchronizer.swift */,
 				518E153F23726A690018541B /* TestDetailedContactViewSynchronizer.swift */,
 				518E154123726F590018541B /* TestCustomContactViewSynchronizer.swift */,
+				B046D07A24B3D65B0005F316 /* TestSimpleContactView.swift */,
+				B046D07C24B3D6670005F316 /* TestDetailedContactView.swift */,
+				B046D07E24B3DD5B0005F316 /* TestDetailedContactViewModel.swift */,
 			);
 			path = Contact;
 			sourceTree = "<group>";
@@ -828,6 +848,16 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		B09EFD9A24AB6D9700FF5C4F /* Contact */ = {
+			isa = PBXGroup;
+			children = (
+				B0B50D3324ABCD4900AC8192 /* SynchronizedContactView.swift */,
+				B09EFD9B24AB711500FF5C4F /* SimpleContactView.swift */,
+				B0A3840424B0B73100384A64 /* DetailedContactView.swift */,
+			);
+			path = Contact;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -995,6 +1025,8 @@
 				51FF9B8E2373377500BAEDB2 /* TestWeekCalendarViewSynchronizer.swift in Sources */,
 				51757C7B2450CF6E0081F133 /* TestTaskEvents.swift in Sources */,
 				510591232378FF24004EDC84 /* TestGridTaskViewSynchronizer.swift in Sources */,
+				B046D07B24B3D65B0005F316 /* TestSimpleContactView.swift in Sources */,
+				B046D07F24B3DD5B0005F316 /* TestDetailedContactViewModel.swift in Sources */,
 				519990712448B864005CD581 /* TestNumericProgressTaskViewModel.swift in Sources */,
 				517C784A239860C1005B2549 /* TestCustomTaskViewSynchronizer.swift in Sources */,
 				5105912523790D06004EDC84 /* TestMockTaskEvents.swift in Sources */,
@@ -1004,6 +1036,7 @@
 				51168D97246E1EFB0002CC69 /* TestSimpleTaskView.swift in Sources */,
 				51D8E27F24115D7D0026C716 /* TestListView.swift in Sources */,
 				51AF51542498420D005D385F /* TestLabeledValueTaskViewModel.swift in Sources */,
+				B046D07D24B3D6670005F316 /* TestDetailedContactView.swift in Sources */,
 				511372462374DFBD00831191 /* TestSynchronizedContext.swift in Sources */,
 				51168D99246E20B40002CC69 /* TestNumericProgressTaskView.swift in Sources */,
 				51D544932397584D00898683 /* Array+Extension.swift in Sources */,
@@ -1025,6 +1058,7 @@
 				51178E0D23AAAA2A0068BAB1 /* OCKSynchronizationContext.swift in Sources */,
 				515862CA23A9C4D600630AB5 /* InstructionsTaskView.swift in Sources */,
 				51178E0323AA95270068BAB1 /* OCKChecklistTaskController.swift in Sources */,
+				B046D07924B3BD630005F316 /* OCKContactController+Extensions.swift in Sources */,
 				51355EEA2499852D009DE0A4 /* OCKTaskEvents+Extension.swift in Sources */,
 				51178E0123AA95270068BAB1 /* OCKTaskController.swift in Sources */,
 				51178E1023AAAA2A0068BAB1 /* OCKSynchronizedStoreManager+Publishers.swift in Sources */,
@@ -1058,6 +1092,7 @@
 				517F3E4523345872004FE251 /* OCKCartesianChartView+Updatable.swift in Sources */,
 				5112730E235E3B12007B18DF /* OCKDetailedContactViewController.swift in Sources */,
 				51AF514E24983B86005D385F /* LabeledValueTaskView.swift in Sources */,
+				B09EFD9C24AB711500FF5C4F /* SimpleContactView.swift in Sources */,
 				515E17D22351262100637153 /* OCKTaskEvents.swift in Sources */,
 				5167B92F23343A64002BC69C /* OCKHeaderView+Updatable.swift in Sources */,
 				5112731A235E588B007B18DF /* OCKCartesianChartController.swift in Sources */,
@@ -1072,11 +1107,14 @@
 				51127322235E58E8007B18DF /* OCKInstructionsTaskController.swift in Sources */,
 				64EABDF12321B1AF00CFBB9F /* UIViewController+Extensions.swift in Sources */,
 				51108C6523596BBD0029F7A2 /* OCKSynchronizationContext.swift in Sources */,
+				B046D07824B3BD630005F316 /* OCKContactController+Extensions.swift in Sources */,
 				51127320235E58D5007B18DF /* OCKSimpleTaskController.swift in Sources */,
+				B0A3840524B0B73100384A64 /* DetailedContactView.swift in Sources */,
 				51AA2304234E687B00A90DA2 /* OCKSimpleContactViewSynchronizer.swift in Sources */,
 				64EABE002321B1AF00CFBB9F /* OCKStoreNotifications.swift in Sources */,
 				51AF515024983BE8005D385F /* OCKLabeledValueTaskController.swift in Sources */,
 				51AF515824984B6F005D385F /* Number+Extension.swift in Sources */,
+				B0B50D3424ABCD4900AC8192 /* SynchronizedContactView.swift in Sources */,
 				5183EA8C2353BC7600C46113 /* OCKScheduleUtility.swift in Sources */,
 				510A6656236147FF00074275 /* OCKAnyEvent+Extension.swift in Sources */,
 				517F3E4A23345BE9004FE251 /* OCKDetailedContactView+Updatable.swift in Sources */,

--- a/CareKit/CareKit/Shared/Contact/DetailedContactView.swift
+++ b/CareKit/CareKit/Shared/Contact/DetailedContactView.swift
@@ -1,0 +1,138 @@
+//
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import CareKitUI
+import Foundation
+import SwiftUI
+
+/// A card that displays information for a contact. The header is an `OCKHeaderView`
+/// The body contains a multi-line istructions label, and four buttons; call, message,
+/// email, and address. The first three buttons have title labels and image views that can
+/// be modified, while the last has a title label, body label, and image view.
+///
+///     +-------------------------------------------------------+
+///     | +------+                                              |
+///     | | icon | [title]                                      |
+///     | | img  | [detail]                                     |
+///     | +------+                                              |
+///     |                                                       |
+///     |  --------------------------------------------------   |
+///     |                                                       |
+///     | [Instructions]                                        |
+///     |                                                       |
+///     | +------------+      +------------+     +------------+ |
+///     | |  [title]   |      |   [title]  |     |   [title]  | |
+///     | |            |      |            |     |            | |
+///     | +------------+      +------------+     +------------+ |
+///     |                                                       |
+///     | +---------------------------------------------------+ |
+///     | |  [title]                                          | |
+///     | |  [detail]                                         | |
+///     | |                                                   | |
+///     | +---------------------------------------------------+ |
+///     +-------------------------------------------------------+
+///
+@available(iOS 14.0, watchOS 7.0, *)
+public struct DetailedContactView<Header: View, Footer: View>: View {
+    private typealias ContactView = SynchronizedContactView<OCKDetailedContactController, CareKitUI.DetailedContactView<Header, Footer>>
+
+    private let contactView: ContactView
+    
+    public var body: some View {
+        contactView
+    }
+
+    private init(contactView: ContactView) {
+        self.contactView = contactView
+    }
+    
+    public init(contactID: String, storeManager: OCKSynchronizedStoreManager, content: @escaping (_ controller: OCKDetailedContactController) -> CareKitUI.DetailedContactView<Header, Footer>) {
+        contactView = .init(controller: .init(storeManager: storeManager), query: .contactID(contactID), content: content)
+    }
+    
+    public init(contact: OCKAnyContact, contactQuery: OCKContactQuery, storeManager: OCKSynchronizedStoreManager,
+                content: @escaping (_ controller: OCKDetailedContactController) -> CareKitUI.DetailedContactView<Header, Footer>) {
+        contactView = .init(controller: .init(storeManager: storeManager), query: .init(.contact(contact)), content: content)
+    }
+    
+    public init(controller: OCKDetailedContactController, content: @escaping (_ controller: OCKDetailedContactController) -> CareKitUI.DetailedContactView<Header, Footer>) {
+        contactView = .init(controller: controller, content: content)
+    }
+    
+    public func onError(_ perform: @escaping (Error) -> Void) -> DetailedContactView<Header, Footer> {
+        .init(contactView: .init(copying: contactView, settingErrorHandler: perform))
+    }
+}
+
+@available(iOS 14.0, watchOS 7.0, *)
+public extension DetailedContactView where Header == _DetailedContactViewHeader, Footer == _DetailedContactViewFooter {
+    init(contactID: String, storeManager: OCKSynchronizedStoreManager) {
+        self.init(contactID: contactID, storeManager: storeManager) {
+            .init(viewModel: $0.viewModel)
+        }
+    }
+    
+    init(contact: OCKAnyContact,contactQuery: OCKContactQuery, storeManager: OCKSynchronizedStoreManager) {
+        self.init(contact: contact, contactQuery: contactQuery, storeManager: storeManager) {
+            .init(viewModel: $0.viewModel)
+        }
+    }
+    
+    init(controller: OCKDetailedContactController) {
+        contactView = .init(controller: controller) {
+            .init(viewModel: $0.viewModel)
+        }
+    }
+}
+
+// CODE REVIEW: Let's add actions - they are nil right now, see UIKit version
+private extension CareKitUI.DetailedContactView where Header == _DetailedContactViewHeader, Footer == _DetailedContactViewFooter {
+    init(viewModel: ContactViewModel?) {
+        self.init(title: Text(viewModel?.title ?? ""), detail: Text(viewModel?.detail ?? ""), instructions: Text(viewModel?.instructions ?? ""), image: Image(systemName: "person.crop.circle"), disclosureImage: nil, callButton: ContactButton(title: Text("Call"), image: Image(systemName: "phone"), action: nil), messageButton: ContactButton(title: Text("Message"), image: Image(systemName: "text.bubble"), action: nil), emailButton:  ContactButton(title: Text("E-mail"), image: Image(systemName: "envelope"), action: nil), addressButton: AddressButton(title: Text("Address"), detail: Text(viewModel?.address ?? ""), image: Image(systemName: "location"), action: nil))
+    }
+}
+
+/// Data used to create a `CareKitUI.DetailedContactView`.
+public struct ContactViewModel {
+
+    /// The title text to display in the header.
+    public let title: String
+
+    /// The detail text to display in the header.
+    public let detail: String?
+    
+    /// The instructions text to display under the header.
+    public let instructions: String?
+    
+    /// The address text to display under the address button.
+    public let address: String?
+}

--- a/CareKit/CareKit/Shared/Contact/SimpleContactView.swift
+++ b/CareKit/CareKit/Shared/Contact/SimpleContactView.swift
@@ -1,0 +1,103 @@
+//
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKitStore
+import CareKitUI
+import Foundation
+import SwiftUI
+
+/// A card that displays information for a contact.
+///
+///     +-------------------------------------------------------+
+///     | +------+                                              |
+///     | | icon | [title]                       [detail        |
+///     | | img  | [detail]                       disclosure]   |
+///     | +------+                                              |
+///     +-------------------------------------------------------+
+///
+@available(iOS 14.0, watchOS 7.0, *)
+public struct SimpleContactView<Header: View, DetailDisclosure: View>: View {
+    private typealias ContactView = SynchronizedContactView<OCKSimpleContactController, CareKitUI.SimpleContactView<Header, DetailDisclosure>>
+
+    private let contactView: ContactView
+    
+    public var body: some View {
+        contactView
+    }
+
+    private init(contactView: ContactView) {
+        self.contactView = contactView
+    }
+    
+    public init(contactID: String, storeManager: OCKSynchronizedStoreManager, content: @escaping (_ controller: OCKSimpleContactController) -> CareKitUI.SimpleContactView<Header, DetailDisclosure>) {
+        contactView = .init(controller: .init(storeManager: storeManager), query: .contactID(contactID), content: content)
+    }
+    
+    public init(contact: OCKAnyContact, contactQuery: OCKContactQuery, storeManager: OCKSynchronizedStoreManager,
+                content: @escaping (_ controller: OCKSimpleContactController) -> CareKitUI.SimpleContactView<Header, DetailDisclosure>) {
+        contactView = .init(controller: .init(storeManager: storeManager), query: .init(.contact(contact)), content: content)
+    }
+    
+    public init(controller: OCKSimpleContactController, content: @escaping (_ controller: OCKSimpleContactController) -> CareKitUI.SimpleContactView<Header, DetailDisclosure>) {
+        contactView = .init(controller: controller, content: content)
+    }
+    
+    public func onError(_ perform: @escaping (Error) -> Void) -> SimpleContactView<Header, DetailDisclosure> {
+        .init(contactView: .init(copying: contactView, settingErrorHandler: perform))
+    }
+}
+
+@available(iOS 14.0, watchOS 7.0, *)
+public extension SimpleContactView where Header == HeaderView, DetailDisclosure == _SimpleContactViewDetailDisclosure {
+    init(contactID: String, storeManager: OCKSynchronizedStoreManager) {
+        self.init(contactID: contactID, storeManager: storeManager) {
+            .init(viewModel: $0.viewModel)
+        }
+    }
+    
+    init(contact: OCKAnyContact,contactQuery: OCKContactQuery, storeManager: OCKSynchronizedStoreManager) {
+        self.init(contact: contact, contactQuery: contactQuery, storeManager: storeManager) {
+            .init(viewModel: $0.viewModel)
+        }
+    }
+    
+    init(controller: OCKSimpleContactController) {
+        contactView = .init(controller: controller) {
+            .init(viewModel: $0.viewModel)
+        }
+    }
+}
+
+private extension CareKitUI.SimpleContactView where Header == HeaderView, DetailDisclosure == _SimpleContactViewDetailDisclosure {
+    init(viewModel: ContactViewModel?) {
+        self.init(title: Text(viewModel?.title ?? ""), detail: Text(viewModel?.detail ?? ""), image: Image(systemName: "person.crop.circle"))
+    }
+}

--- a/CareKit/CareKit/Shared/Extensions/OCKContactController+Extensions.swift
+++ b/CareKit/CareKit/Shared/Extensions/OCKContactController+Extensions.swift
@@ -1,3 +1,4 @@
+//
 /*
  Copyright (c) 2020, Apple Inc. All rights reserved.
  
@@ -28,28 +29,41 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Foundation
-import SwiftUI
+import CareKitStore
+import Combine
+import Contacts
 
-extension View {
+extension OCKContactController {
 
-    /// Conditionally apply modifiers to a view.
-    func `if`<TrueContent: View>(_ condition: Bool, trueContent: (Self) -> TrueContent) -> some View {
-        condition ?
-            ViewBuilder.buildEither(first: trueContent(self)) :
-            ViewBuilder.buildEither(second: self)
+    var viewModel: ContactViewModel? { makeViewModel(from: contact) }
+    
+    private func makeViewModel(from contact: OCKAnyContact?) -> ContactViewModel? {
+        guard let contact = contact else { return  nil }
+
+        return .init(title: formatName(contact.name), detail: contact.title, instructions: contact.role, address: formatAddress(contact.address))
     }
 
-    /// Opposite effect of applying a `mask`. This will use the alpha channel of the mask to cut a shape out of the view.
-    func inverseMask<Mask: View>(_ mask: Mask) -> some View {
-        self.mask(mask
-            .foregroundColor(.black)
-            .background(Color.white)
-            .compositingGroup()
-            .luminanceToAlpha())
+    // CODE REVIEW: Why is the formatName parameter optinal?
+    private func formatName(_ name: PersonNameComponents?) -> String {
+        guard let name = name else {
+            return ""
+        }
+        let formatter = PersonNameComponentsFormatter()
+        formatter.style = .medium
+        
+        return formatter.string(from: name)
     }
     
-    func scaled(size: CGFloat) -> some View {
-        return self.modifier(ScaledFontModifier(size: size))
+    // CODE REVIEW: Why is the address parameter optinal?
+    // CODE REVIEW: Why is the return type non-optional?
+    private func formatAddress(_ address: OCKPostalAddress?) -> String {
+        guard let address = address else {
+            return ""
+        }
+        let formatter = CNPostalAddressFormatter()
+        formatter.style = .mailingAddress
+        
+        return formatter.string(from: address)
     }
 }
+

--- a/CareKit/CareKitTests/Contact/TestDetailedContactView.swift
+++ b/CareKit/CareKitTests/Contact/TestDetailedContactView.swift
@@ -1,0 +1,63 @@
+//
+/*
+ Copyright (c) 2020, Apple Inc. All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+ 
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+ 
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import CareKit
+import CareKitStore
+import CareKitUI
+import Foundation
+import SwiftUI
+import XCTest
+
+@available(iOS 14.0, watchOS 7.0, *)
+class TestDetailedContactView: XCTestCase {
+
+    let controller: OCKDetailedContactController = {
+        let store = OCKStore(name: "carekit-store", type: .onDisk)
+        return .init(storeManager: .init(wrapping: store))
+    }()
+
+    let query = OCKContactQuery(id: "lexi-torres")
+    let data = OCKContact(id: "lexi-torres", givenName: "Lexi", familyName: "Torres", carePlanUUID: nil)
+    // CODE REVIEW: Let's break this long line down into multiple lines
+    let staticView = CareKitUI.DetailedContactView(title: Text(""), detail: Text(""), instructions: Text(""), image: Image(systemName: "person.crop.circle"), disclosureImage: nil, callButton: ContactButton(title: Text("Call"), image: Image(systemName: "phone"), action: nil), messageButton: ContactButton(title: Text("Message"), image: Image(systemName: "text.bubble"), action: nil), emailButton:  ContactButton(title: Text("E-mail"), image: Image(systemName: "envelope"), action: nil), addressButton: AddressButton(title: Text("Address"), detail: Text(""), image: Image(systemName: "location"), action: nil))
+
+    func testDefaultContentInitializers() {
+        _ = CareKit.DetailedContactView(contact: data, contactQuery: query, storeManager: controller.storeManager)
+        _ = CareKit.DetailedContactView(contactID: "lexi-torres", storeManager:  controller.storeManager)
+        _ = CareKit.DetailedContactView(controller: controller)
+    }
+
+    func testCustomContentInitializers() {
+        _ = CareKit.DetailedContactView(contact: data, contactQuery: query, storeManager: controller.storeManager) { _ in self.staticView }
+        _ = CareKit.DetailedContactView(contactID: "lexi-torres", storeManager: controller.storeManager) { _ in self.staticView }
+        _ = CareKit.DetailedContactView(controller: controller) { _ in self.staticView }
+    }
+}

--- a/CareKit/CareKitTests/Contact/TestSimpleContactView.swift
+++ b/CareKit/CareKitTests/Contact/TestSimpleContactView.swift
@@ -1,3 +1,4 @@
+//
 /*
  Copyright (c) 2020, Apple Inc. All rights reserved.
  
@@ -28,28 +29,34 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import CareKit
+import CareKitStore
+import CareKitUI
 import Foundation
 import SwiftUI
+import XCTest
 
-extension View {
+@available(iOS 14.0, watchOS 7.0, *)
+class TestSimpleContactView: XCTestCase {
 
-    /// Conditionally apply modifiers to a view.
-    func `if`<TrueContent: View>(_ condition: Bool, trueContent: (Self) -> TrueContent) -> some View {
-        condition ?
-            ViewBuilder.buildEither(first: trueContent(self)) :
-            ViewBuilder.buildEither(second: self)
+    let controller: OCKSimpleContactController = {
+        let store = OCKStore(name: "carekit-store", type: .onDisk)
+        return .init(storeManager: .init(wrapping: store))
+    }()
+
+    let query = OCKContactQuery(id: "lexi-torres")
+    let data = OCKContact(id: "lexi-torres", givenName: "Lexi", familyName: "Torres", carePlanUUID: nil)
+    let staticView = CareKitUI.SimpleContactView(title: Text("Title"), detail: Text("Detail"), image: Image(systemName: "person.crop.circle"))
+
+    func testDefaultContentInitializers() {
+        _ = CareKit.SimpleContactView(contact: data, contactQuery: query, storeManager: controller.storeManager)
+        _ = CareKit.SimpleContactView(contactID: "lexi-torres", storeManager:  controller.storeManager)
+        _ = CareKit.SimpleContactView(controller: controller)
     }
 
-    /// Opposite effect of applying a `mask`. This will use the alpha channel of the mask to cut a shape out of the view.
-    func inverseMask<Mask: View>(_ mask: Mask) -> some View {
-        self.mask(mask
-            .foregroundColor(.black)
-            .background(Color.white)
-            .compositingGroup()
-            .luminanceToAlpha())
-    }
-    
-    func scaled(size: CGFloat) -> some View {
-        return self.modifier(ScaledFontModifier(size: size))
+    func testCustomContentInitializers() {
+        _ = CareKit.SimpleContactView(contact: data, contactQuery: query, storeManager: controller.storeManager) { _ in self.staticView }
+        _ = CareKit.SimpleContactView(contactID: "lexi-torres", storeManager: controller.storeManager) { _ in self.staticView }
+        _ = CareKit.SimpleContactView(controller: controller) { _ in self.staticView }
     }
 }

--- a/CareKitUI/CareKitUI.xcodeproj/project.pbxproj
+++ b/CareKitUI/CareKitUI.xcodeproj/project.pbxproj
@@ -122,6 +122,19 @@
 		64E1BD4E2309FCF200DFFE52 /* OCKResponsiveLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E1BD4D2309FCF200DFFE52 /* OCKResponsiveLayout.swift */; };
 		64EEC2382318253B00B1012F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 64EEC2362318253B00B1012F /* Localizable.strings */; };
 		64EEC23B231825DD00B1012F /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EEC23A231825DD00B1012F /* OCKLocalization.swift */; };
+		B06D959024B520D6004578B6 /* FontModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06D958F24B520D6004578B6 /* FontModifiers.swift */; };
+		B0703E7624AB5C1900250ED7 /* DetailedContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0703E7424AB5C1900250ED7 /* DetailedContactView.swift */; };
+		B0703E7724AB5C1900250ED7 /* SimpleContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0703E7524AB5C1900250ED7 /* SimpleContactView.swift */; };
+		B09EFD9024AB616700FF5C4F /* CheckmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8B24AB616700FF5C4F /* CheckmarkButton.swift */; };
+		B09EFD9124AB616700FF5C4F /* CheckmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8B24AB616700FF5C4F /* CheckmarkButton.swift */; };
+		B09EFD9224AB616700FF5C4F /* ChecklistItemButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8C24AB616700FF5C4F /* ChecklistItemButton.swift */; };
+		B09EFD9324AB616700FF5C4F /* ChecklistItemButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8C24AB616700FF5C4F /* ChecklistItemButton.swift */; };
+		B09EFD9424AB616700FF5C4F /* AnimatedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8D24AB616700FF5C4F /* AnimatedButton.swift */; };
+		B09EFD9524AB616700FF5C4F /* AnimatedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8D24AB616700FF5C4F /* AnimatedButton.swift */; };
+		B09EFD9624AB616700FF5C4F /* ContactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8E24AB616700FF5C4F /* ContactButton.swift */; };
+		B09EFD9724AB616700FF5C4F /* ContactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8E24AB616700FF5C4F /* ContactButton.swift */; };
+		B09EFD9824AB616700FF5C4F /* AddressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8F24AB616700FF5C4F /* AddressButton.swift */; };
+		B09EFD9924AB616700FF5C4F /* AddressButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09EFD8F24AB616700FF5C4F /* AddressButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -236,6 +249,14 @@
 		64E1BD4D2309FCF200DFFE52 /* OCKResponsiveLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCKResponsiveLayout.swift; sourceTree = "<group>"; };
 		64EEC2372318253B00B1012F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		64EEC23A231825DD00B1012F /* OCKLocalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCKLocalization.swift; sourceTree = "<group>"; };
+		B06D958F24B520D6004578B6 /* FontModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontModifiers.swift; sourceTree = "<group>"; };
+		B0703E7424AB5C1900250ED7 /* DetailedContactView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailedContactView.swift; sourceTree = "<group>"; };
+		B0703E7524AB5C1900250ED7 /* SimpleContactView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleContactView.swift; sourceTree = "<group>"; };
+		B09EFD8B24AB616700FF5C4F /* CheckmarkButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckmarkButton.swift; sourceTree = "<group>"; };
+		B09EFD8C24AB616700FF5C4F /* ChecklistItemButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChecklistItemButton.swift; sourceTree = "<group>"; };
+		B09EFD8D24AB616700FF5C4F /* AnimatedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedButton.swift; sourceTree = "<group>"; };
+		B09EFD8E24AB616700FF5C4F /* ContactButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactButton.swift; sourceTree = "<group>"; };
+		B09EFD8F24AB616700FF5C4F /* AddressButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -296,6 +317,7 @@
 				51B2259A23EDDCFC00A2D11F /* NoHighlightStyle.swift */,
 				516A1C47244F766A00BBF2D3 /* OSValue.swift */,
 				510466F624A2842A00D0FD53 /* Components */,
+				B0703E7324AB5C1900250ED7 /* Contact */,
 				510466EE24A26C1800D0FD53 /* Task */,
 				518F9D7022961BF5009CAA48 /* Style */,
 				510466EF24A278EF00D0FD53 /* Extensions */,
@@ -324,6 +346,7 @@
 		510466EF24A278EF00D0FD53 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B06D958E24B520BF004578B6 /* Modifiers */,
 				516A1C4E244FA7E500BBF2D3 /* View+Extension.swift */,
 				51EFC75423FCAE6000536266 /* UIColor+Extension.swift */,
 				5103C55122F37B44007A7403 /* Number+Extensions.swift */,
@@ -370,6 +393,7 @@
 		510466F624A2842A00D0FD53 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				B09EFD8A24AB616700FF5C4F /* Controls */,
 				51B2259E23EDDCFC00A2D11F /* CardView.swift */,
 				51B2259F23EDDCFC00A2D11F /* HeaderView.swift */,
 				51173F3D243FE022004CB150 /* RectangularCompletionView.swift */,
@@ -651,6 +675,35 @@
 			path = Localization;
 			sourceTree = "<group>";
 		};
+		B06D958E24B520BF004578B6 /* Modifiers */ = {
+			isa = PBXGroup;
+			children = (
+				B06D958F24B520D6004578B6 /* FontModifiers.swift */,
+			);
+			path = Modifiers;
+			sourceTree = "<group>";
+		};
+		B0703E7324AB5C1900250ED7 /* Contact */ = {
+			isa = PBXGroup;
+			children = (
+				B0703E7424AB5C1900250ED7 /* DetailedContactView.swift */,
+				B0703E7524AB5C1900250ED7 /* SimpleContactView.swift */,
+			);
+			path = Contact;
+			sourceTree = "<group>";
+		};
+		B09EFD8A24AB616700FF5C4F /* Controls */ = {
+			isa = PBXGroup;
+			children = (
+				B09EFD8B24AB616700FF5C4F /* CheckmarkButton.swift */,
+				B09EFD8C24AB616700FF5C4F /* ChecklistItemButton.swift */,
+				B09EFD8D24AB616700FF5C4F /* AnimatedButton.swift */,
+				B09EFD8E24AB616700FF5C4F /* ContactButton.swift */,
+				B09EFD8F24AB616700FF5C4F /* AddressButton.swift */,
+			);
+			path = Controls;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -856,6 +909,7 @@
 				510CC634243B843C008BD6B3 /* os_log+CareKitUI.swift in Sources */,
 				518F9D8922961BF5009CAA48 /* OCKDetailedContactView.swift in Sources */,
 				518F9D9722961BF5009CAA48 /* OCKGradientPlotView.swift in Sources */,
+				B09EFD9024AB616700FF5C4F /* CheckmarkButton.swift in Sources */,
 				51F12D39229C81E200CA265B /* OCKLabeledCheckmarkButton.swift in Sources */,
 				518F9DAE22961BF6009CAA48 /* OCKColorStyler.swift in Sources */,
 				510D862D23020D410073776E /* OCKStyler.swift in Sources */,
@@ -863,15 +917,19 @@
 				5136794C243BF6EC0026997B /* SafariView.swift in Sources */,
 				51173F3C243FE007004CB150 /* CircularCompletionView.swift in Sources */,
 				516A02BA22F363AE00D55AD7 /* NSLayoutConstraint+Extensions.swift in Sources */,
+				B09EFD9424AB616700FF5C4F /* AnimatedButton.swift in Sources */,
 				51F75B942447DD0B00978C71 /* NumericProgressTaskView.swift in Sources */,
 				518F9D9322961BF5009CAA48 /* OCKButtonLogTaskView.swift in Sources */,
 				518F9DB522961BF6009CAA48 /* OCKWeekCalendarView.swift in Sources */,
 				03089D7F231ED7AF0054EA23 /* Calendar+Extensions.swift in Sources */,
+				B09EFD9824AB616700FF5C4F /* AddressButton.swift in Sources */,
 				51367952243BF7450026997B /* LinkLabel.swift in Sources */,
 				518F9D9822961BF5009CAA48 /* OCKGraphLegendView.swift in Sources */,
+				B06D959024B520D6004578B6 /* FontModifiers.swift in Sources */,
 				518F9DC022961BF6009CAA48 /* OCKStackView.swift in Sources */,
 				51EFC75623FCAE6000536266 /* UIColor+Extension.swift in Sources */,
 				518F9D9922961BF5009CAA48 /* OCKScatterPlotView.swift in Sources */,
+				B0703E7624AB5C1900250ED7 /* DetailedContactView.swift in Sources */,
 				5196B54322D5872C00800706 /* OCKTaskDisplayable.swift in Sources */,
 				518F9DA722961BF6009CAA48 /* OCKCompletionRingView.swift in Sources */,
 				518F9D9122961BF5009CAA48 /* OCKLabeledButton.swift in Sources */,
@@ -892,13 +950,16 @@
 				518F9D8F22961BF5009CAA48 /* OCKChecklistItemButton.swift in Sources */,
 				518F9DB722961BF6009CAA48 /* OCKSeparatorView.swift in Sources */,
 				516A02BC22F363D900D55AD7 /* OCKView.swift in Sources */,
+				B09EFD9624AB616700FF5C4F /* ContactButton.swift in Sources */,
 				518F9DB122961BF6009CAA48 /* OCKAppearanceStyler.swift in Sources */,
 				518F9DA222961BF6009CAA48 /* OCKBarPlotView.swift in Sources */,
 				510A5762234A7B920006C376 /* OCKAnimatedButton.swift in Sources */,
+				B0703E7724AB5C1900250ED7 /* SimpleContactView.swift in Sources */,
 				518F9DAB22961BF6009CAA48 /* UIFont+Extensions.swift in Sources */,
 				5103C55222F37B44007A7403 /* Number+Extensions.swift in Sources */,
 				64E1BD4E2309FCF200DFFE52 /* OCKResponsiveLayout.swift in Sources */,
 				51B225A923EDDCFC00A2D11F /* CardView.swift in Sources */,
+				B09EFD9224AB616700FF5C4F /* ChecklistItemButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -912,14 +973,19 @@
 				516A1C50244FA7E900BBF2D3 /* View+Extension.swift in Sources */,
 				51F9F13323A9B9F80087C900 /* OCKDimensionStyler.swift in Sources */,
 				516A1C46244F703000BBF2D3 /* Number+Extensions.swift in Sources */,
+				B09EFD9724AB616700FF5C4F /* ContactButton.swift in Sources */,
 				51E76F1D24004F19008B09E7 /* NoHighlightStyle.swift in Sources */,
 				51F9F13423A9B9FF0087C900 /* OCKStyler.swift in Sources */,
 				51F9F13123A9B9F80087C900 /* OCKAnimationStyler.swift in Sources */,
+				B09EFD9324AB616700FF5C4F /* ChecklistItemButton.swift in Sources */,
 				510466F524A283E500D0FD53 /* InstructionsTaskView.swift in Sources */,
 				51E214292444F1520063A121 /* RectangularCompletionView.swift in Sources */,
 				516A1C49244F766A00BBF2D3 /* OSValue.swift in Sources */,
+				B09EFD9124AB616700FF5C4F /* CheckmarkButton.swift in Sources */,
+				B09EFD9924AB616700FF5C4F /* AddressButton.swift in Sources */,
 				51D5C97124A2947A00EC45B5 /* os_log+CareKitUI.swift in Sources */,
 				51F9F13223A9B9F80087C900 /* OCKAppearanceStyler.swift in Sources */,
+				B09EFD9524AB616700FF5C4F /* AnimatedButton.swift in Sources */,
 				51E76F1E24004F1F008B09E7 /* CardView.swift in Sources */,
 				51E76F2024004F25008B09E7 /* SimpleTaskView.swift in Sources */,
 				51EFC75723FCAE6000536266 /* UIColor+Extension.swift in Sources */,

--- a/CareKitUI/CareKitUI/Shared/Components/HeaderView.swift
+++ b/CareKitUI/CareKitUI/Shared/Components/HeaderView.swift
@@ -56,8 +56,9 @@ public struct HeaderView: View {
     public var body: some View {
         HStack(spacing: style.dimension.directionalInsets2.trailing) {
             image?
-                .font(.largeTitle)
-                .foregroundColor(Color(UIColor.lightGray))
+                .scaled(size: style.dimension.imageHeight2)
+                .foregroundColor(Color(style.color.customGray3))
+
             VStack(alignment: .leading, spacing: style.dimension.directionalInsets1.top / 4.0) {
                 title
                     .font(.headline)

--- a/CareKitUI/CareKitUI/Shared/Extensions/Modifiers/FontModifiers.swift
+++ b/CareKitUI/CareKitUI/Shared/Extensions/Modifiers/FontModifiers.swift
@@ -1,3 +1,4 @@
+//
 /*
  Copyright (c) 2020, Apple Inc. All rights reserved.
  
@@ -28,28 +29,17 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Foundation
 import SwiftUI
 
-extension View {
-
-    /// Conditionally apply modifiers to a view.
-    func `if`<TrueContent: View>(_ condition: Bool, trueContent: (Self) -> TrueContent) -> some View {
-        condition ?
-            ViewBuilder.buildEither(first: trueContent(self)) :
-            ViewBuilder.buildEither(second: self)
-    }
-
-    /// Opposite effect of applying a `mask`. This will use the alpha channel of the mask to cut a shape out of the view.
-    func inverseMask<Mask: View>(_ mask: Mask) -> some View {
-        self.mask(mask
-            .foregroundColor(.black)
-            .background(Color.white)
-            .compositingGroup()
-            .luminanceToAlpha())
-    }
+public struct ScaledFontModifier: ViewModifier {
+    @Environment(\.careKitStyle) private var style
+    @Environment(\.sizeCategory) var sizeCategory
+    var size: CGFloat
     
-    func scaled(size: CGFloat) -> some View {
-        return self.modifier(ScaledFontModifier(size: size))
+    public func body(content: Content) -> some View {
+        let scaledSize = UIFontMetrics.default.scaledValue(for: size)
+        return content
+                .font(.system(size: scaledSize))
+            
     }
 }

--- a/OCKCatalog/OCKCatalog/Sections/ContactSection.swift
+++ b/OCKCatalog/OCKCatalog/Sections/ContactSection.swift
@@ -30,6 +30,7 @@
 
 import CareKit
 import CareKitStore
+import CareKitUI
 import Foundation
 import SwiftUI
 
@@ -54,7 +55,15 @@ private struct ContactDestination: View {
         ZStack {
             Color(UIColor.systemGroupedBackground)
                 .edgesIgnoringSafeArea(.all)
-            AdaptedTaskView(style: style, storeManager: storeManager)
+            
+            PlatformPicker {
+                AdaptedContactView(style: style, storeManager: storeManager)
+            } swiftUIView: {
+                if #available(iOS 14, *) {
+                    ContactView(style: style, controller: OCKContactController(storeManager: storeManager))
+                }
+            }
+            
         }
         .navigationBarTitle(Text(style.rawValue.capitalized), displayMode: .inline)
     }
@@ -64,7 +73,7 @@ private enum ContactStyle: String, CaseIterable {
     case simple, detailed
 }
 
-private struct AdaptedTaskView: UIViewControllerRepresentable {
+private struct AdaptedContactView: UIViewControllerRepresentable {
 
     let style: ContactStyle
     let storeManager: OCKSynchronizedStoreManager
@@ -88,4 +97,24 @@ private struct AdaptedTaskView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+@available(iOS 14.0, *)
+private struct ContactView: View {
+    @Environment(\.storeManager) private var storeManager
+
+    let style: ContactStyle
+    let controller: OCKContactController
+    
+    var body: some View {
+        CardBackground {
+            switch style {
+            case .simple:
+                SimpleContactView(contactID: OCKStore.Contacts.matthew.rawValue, storeManager: storeManager)
+            case .detailed:
+                DetailedContactView(contactID: OCKStore.Contacts.matthew.rawValue, storeManager: storeManager)
+            }
+            
+        }
+    }
 }

--- a/OCKCatalog/OCKCatalog/Sections/TaskSection.swift
+++ b/OCKCatalog/OCKCatalog/Sections/TaskSection.swift
@@ -1,4 +1,4 @@
-/*
+  /*
  Copyright (c) 2020, Apple Inc. All rights reserved.
  
  Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
## Objective
This PR introduces simple and detail contact views in the SwiftUI part of CareKit and CareKitUI.

## Interesting points
In the Detailed Contact View, I couldn't use `.subheadline` Font style because it only allows a single line of text. That's probably a bug in SwiftUI. The same code is being used in the InstructionsTaskView alongside with `.lineLimit(nil)` which doesn't have any effect to the line limit.

The HeaderView didn't contain any image up until now. So included the image. We still don't have a way to populate images for contacts in CareKit so all images are just system placeholders for now.

The size of the image and scale of the fonts doesn't correspond 1:1 to the UIKit version. This is because we are using the predefined sizes. If we wanted to use different sizes for these use-cases, we would have to define them in constants.

Looking forward to your feedback!


![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 14 29 49](https://user-images.githubusercontent.com/1864402/87306317-217dc900-c518-11ea-86fc-ab801d2c1ad4.png)
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 14 29 52](https://user-images.githubusercontent.com/1864402/87306324-23e02300-c518-11ea-8d1f-7b8d1e5450ed.png)
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 14 29 58](https://user-images.githubusercontent.com/1864402/87306326-2478b980-c518-11ea-8f45-5e8ffd1b6060.png)
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 14 30 00](https://user-images.githubusercontent.com/1864402/87306329-2478b980-c518-11ea-813f-c1ee3121ebc8.png)
![Simulator Screen Shot - iPhone 11 - 2020-07-13 at 14 43 23](https://user-images.githubusercontent.com/1864402/87306332-25115000-c518-11ea-9328-5962661ad184.png)
